### PR TITLE
Include result in exception

### DIFF
--- a/growatt/__init__.py
+++ b/growatt/__init__.py
@@ -144,5 +144,5 @@ class GrowattApi:
         data = response.json()
         result = data["back"]
         if not "success" in result or not result["success"]:
-            raise GrowattApiError()
+            raise GrowattApiError(result)
         return result


### PR DESCRIPTION
That gives slightly more information in case something goes wrong. However, it
currently only reports something like "errCode: 102", and we don't know what
that means.

This was motivated by issue #6.